### PR TITLE
[#4] ci 파일을 추가하여 lint가 실패한 경우 배포하지 못하게 한다.

### DIFF
--- a/.github/workflows/beta-merge.yml
+++ b/.github/workflows/beta-merge.yml
@@ -1,0 +1,44 @@
+name: 'beta-merge'
+
+on:
+  push:
+    branches:
+    - beta
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+        with:
+          ref: beta
+          
+      - name: Install Dependencies
+        run: yarn
+
+      - name: Build
+        run: yarn build
+      
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-dist
+          path: ./dist
+        
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: build-dist
+          
+      - name: Deploy 
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
+          AWS_S3: ${{ secrets.BETA_DEPLOY_AWS_S3 }}
+        run: |
+          aws s3 sync --region ap-northeast-2 ./ $AWS_S3 --acl public-read --follow-symlinks --delete

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -20,6 +20,9 @@ jobs:
           
       - name: Install Dependencies
         run: yarn    
+      
+      - name: Check lint
+        run: yarn lint
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -1,0 +1,61 @@
+name: 'develop'
+
+on:
+  push:
+    branches:
+    - feature/*
+    - bugfix/*
+    - refactor/*
+    - ci/*
+
+jobs:
+  init:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - run: git checkout HEAD^
+          
+      - name: Install Dependencies
+        run: yarn    
+
+  build:
+    runs-on: ubuntu-latest
+    needs: init
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - run: git checkout HEAD^
+          
+      - name: Install Dependencies
+        run: yarn
+
+      - name: Build
+        run: yarn build
+      
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-dist
+          path: ./dist
+        
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: build-dist
+          
+      - name: Deploy 
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
+          AWS_S3: ${{ secrets.DEV_DEPLOY_AWS_S3 }}
+        run: |
+          aws s3 sync --region ap-northeast-2 ./ $AWS_S3 --acl public-read --follow-symlinks --delete

--- a/.github/workflows/main-merge.yml
+++ b/.github/workflows/main-merge.yml
@@ -1,0 +1,44 @@
+name: 'main-merge'
+
+on:
+  push:
+    branches:
+    - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+        with:
+          ref: main
+          
+      - name: Install Dependencies
+        run: yarn
+
+      - name: Build
+        run: yarn build
+      
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-dist
+          path: ./dist
+        
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: build-dist
+          
+      - name: Deploy 
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
+          AWS_S3: ${{ secrets.PROD_DEPLOY_AWS_S3 }}
+        run: |
+          aws s3 sync --region ap-northeast-2 ./ $AWS_S3 --acl public-read --follow-symlinks --delete


### PR DESCRIPTION
# 관련 이슈

#4 CI 과정을 명시한다.

# 내용

다음과 같은 내용을 구현했습니다.

* [개발 환경 링크](https://lucky-tree-zwsm-dev.s3.ap-northeast-2.amazonaws.com/index.html), [베타 환경 링크](https://lucky-tree-zwsm-beta.s3.ap-northeast-2.amazonaws.com/index.html) 에서 개발한 내용을 확인 할 수 있습니다.
* 개발한 내용은 각 branch에 push하게 되면 lint 확인 -> build -> 배포까지하게 됩니다.

| 내용 | 스크린샷 |
| -- | ---- |
| lint에 성공한 경우 배포에 성공한다. |  <img width="850" alt="image" src="https://user-images.githubusercontent.com/20200204/211301463-068ea846-dffb-45ea-936d-014e1267f922.png"> [관련 링크](https://github.com/lucky-treee/ZeroWasteShopMapWebUI/actions/runs/3873450791) |
| lint에 실패한 경우 배포에 실패한다. | <img width="850" alt="image" src="https://user-images.githubusercontent.com/20200204/211300756-7eb20882-0d9d-4104-9e1a-0a2218046a93.png"> [관련 링크](https://github.com/lucky-treee/ZeroWasteShopMapWebUI/actions/runs/3873429744) |