### PR TITLE
[#31] MSW를 사용한 모킹에서 asset을 불러올 때 콘솔 오류를 해결한다.

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,7 +6,9 @@ import 'utils/i18n';
 import { worker } from 'mocks/browser';
 
 if (import.meta.env.MODE === 'development') {
-  worker.start();
+  worker.start({
+    onUnhandledRequest: 'bypass',
+  });
 }
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(


### PR DESCRIPTION
# 관련 이슈

[현재 msw 라이브러리를 사용해서 구현되지 않은 API를 모킹하고 있다. 그러나 구현되지 않은 API만 모킹하는 것이 아니라, 모든 asset에 대한 요청들도 모킹하는 Handler를 찾으면서 콘솔에 오류가 발생한다.](https://github.com/orgs/lucky-treee/projects/4?pane=issue&itemId=19142335)

# 내용

다음과 같은 내용을 구현했습니다.

- API 문서와 콘솔 기록 결과, 작성하지않은 `request handler`에 대해 요청이 이루어질시 발생하는 warn log로 판단이 되었다.
- 이에 대해 명확히 하고자, 작성하지 않은(실제 존재하는 요청)에 대해서는 `bypass`라는 옵션을 주었습니다.
- `bypass`:  Performs an unhandled request as-is.

[start() - API - MSW](https://mswjs.io/docs/api/setup-worker/start#onunhandledrequest)

# 미리보기

| 내용 | 스크린샷 |
| -- | ---- |
