### PR TITLE
[#34] ErrorBoundary를 추가해서 에러 화면을 보여준다.

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -25,6 +25,15 @@ module.exports = {
     'react/require-default-props': 'off',
     'react/jsx-props-no-spreading': 'off',
     'react/function-component-definition': 'off',
+    'no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': [
+      'warn',
+      {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
+      },
+    ],
     'import/no-extraneous-dependencies': [
       'error',
       {

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@100;300;400;500;700;900&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+Mono:wght@100;200;300;400;500;600;700;800;900&display=swap" rel="stylesheet">
     <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=<{ VITE_KAKAO_API_KEY }>&libraries=services,clusterer,drawing"></script>
     <title>품</title>
   </head>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import PathName from 'constants/PathName';
+import NotFoundErrorPage from 'pages/error/NotFoundErrorPage';
 import LoginPage from 'pages/LoginPage';
 import MapPage from 'pages/MapPage';
 import ProfilePage from 'pages/ProfilePage';
@@ -6,20 +7,18 @@ import ShopPage from 'pages/ShopPage';
 import SignUpPage from 'pages/SignUpPage';
 import React from 'react';
 import { Route, Routes } from 'react-router';
-import { BrowserRouter } from 'react-router-dom';
 
 function App() {
   return (
     <React.Suspense fallback={<div>Loading...</div>}>
-      <BrowserRouter>
-        <Routes>
-          <Route path={PathName.MAP_PAGE} element={<MapPage />} />
-          <Route path={PathName.LOGIN_PAGE} element={<LoginPage />} />
-          <Route path={PathName.SIGNUP_PAGE} element={<SignUpPage />} />
-          <Route path={PathName.PROFILE_PAGE} element={<ProfilePage />} />
-          <Route path={PathName.SHOP_PAGE} element={<ShopPage />} />
-        </Routes>
-      </BrowserRouter>
+      <Routes>
+        <Route path={PathName.MAP_PAGE} element={<MapPage />} />
+        <Route path={PathName.LOGIN_PAGE} element={<LoginPage />} />
+        <Route path={PathName.SIGNUP_PAGE} element={<SignUpPage />} />
+        <Route path={PathName.PROFILE_PAGE} element={<ProfilePage />} />
+        <Route path={PathName.SHOP_PAGE} element={<ShopPage />} />
+        <Route path="*" element={<NotFoundErrorPage />} />
+      </Routes>
     </React.Suspense>
   );
 }

--- a/src/ErrorBoundary.tsx
+++ b/src/ErrorBoundary.tsx
@@ -1,0 +1,41 @@
+import React, { Component, ErrorInfo, ReactNode } from 'react';
+import UnknownErrorPage from 'pages/error/UnknownErrorPage';
+
+interface ErrorBoundaryProps {
+  children?: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error?: Error;
+}
+
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: undefined };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    // eslint-disable-next-line no-console
+    console.error('[poom] ErrorBoundary caught error: ', error, errorInfo);
+  }
+
+  render(): ReactNode {
+    const { hasError, error } = this.state;
+
+    const { children } = this.props;
+
+    if (hasError && error !== undefined) {
+      return <UnknownErrorPage error={error} />;
+    }
+
+    return children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/components/Typography.tsx
+++ b/src/components/Typography.tsx
@@ -2,26 +2,43 @@ import React from 'react';
 
 type TypographyProps = {
   children: React.ReactNode;
-  type: 'title' | 'subtitle' | 'caption' | 'body';
+  className?: string;
+  type: 'title' | 'subtitle' | 'caption' | 'body' | 'code';
 };
 
 const Typography: React.FC<TypographyProps> = (props) => {
-  const { children, type } = props;
+  const { children, type, className } = props;
 
   if (type === 'title') {
-    return <h1 className="text-2xl font-bold leading-8">{children}</h1>;
+    return (
+      <h1 className={`text-2xl font-bold leading-8 ${className}`}>
+        {children}
+      </h1>
+    );
   }
   if (type === 'subtitle') {
-    return <h3 className="text-lg font-bold leading-8">{children}</h3>;
+    return (
+      <h3 className={`text-lg font-bold leading-8 ${className}`}>{children}</h3>
+    );
   }
   if (type === 'body') {
-    return <p className="text-sm font-normal leading-5">{children}</p>;
+    return (
+      <p className={`text-sm font-normal leading-5 ${className}`}>{children}</p>
+    );
   }
   if (type === 'caption') {
-    return <p className="text-xs font-normal leading-4">{children}</p>;
+    return (
+      <p className={`text-xs font-normal leading-4 ${className}`}>{children}</p>
+    );
   }
-
-  return <p className="text-sm font-normal leading-5">{children}</p>;
+  if (type === 'code') {
+    return (
+      <p className={`text-sm font-mono leading-4 ${className}`}>{children}</p>
+    );
+  }
+  return (
+    <p className={`text-sm font-normal leading-5 ${className}`}>{children}</p>
+  );
 };
 
 export default Typography;

--- a/src/index.css
+++ b/src/index.css
@@ -3,7 +3,6 @@
 @tailwind utilities;
 
 * {
-  font-family: 'Noto Sans KR', Roboto, sans-serif;
   -webkit-touch-callout: none;
   -webkit-user-select: none;
   -webkit-tap-highlight-color: transparent;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import App from 'App';
-import 'index.css';
-import 'utils/i18n';
 import { worker } from 'mocks/browser';
+import ErrorBoundary from 'ErrorBoundary';
+import 'utils/i18n';
+import 'index.css';
 
 if (import.meta.env.MODE === 'development') {
   worker.start({
@@ -13,6 +15,10 @@ if (import.meta.env.MODE === 'development') {
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <ErrorBoundary>
+        <App />
+      </ErrorBoundary>
+    </BrowserRouter>
   </React.StrictMode>
 );

--- a/src/pages/error/NotFoundErrorPage.tsx
+++ b/src/pages/error/NotFoundErrorPage.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router';
+import Typography from 'components/Typography';
+import PathName from 'constants/PathName';
+
+const NotFoundErrorPage: React.FC = () => {
+  const { t } = useTranslation();
+
+  const navigate = useNavigate();
+
+  const handleBackToHomeButtonClick = () => navigate(PathName.MAP_PAGE);
+
+  return (
+    <div className="flex justify-between items-center flex-col pt-12 pl-12 pr-12 pb-12 h-screen">
+      <div className="flex gap-2 flex-col w-full">
+        <Typography type="title">{t('not-found-error-page-title')}</Typography>
+        <Typography type="body">
+          {t('not-found-error-page-description')}
+        </Typography>
+      </div>
+      <button
+        className="px-6 py-2 rounded-md bg-primary hover:pg-primary-hover text-white w-fit"
+        type="button"
+        onClick={handleBackToHomeButtonClick}
+      >
+        {t('back-to-home-button-text')}
+      </button>
+    </div>
+  );
+};
+
+export default NotFoundErrorPage;

--- a/src/pages/error/UnknownErrorPage.tsx
+++ b/src/pages/error/UnknownErrorPage.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import Typography from 'components/Typography';
+import PathName from 'constants/PathName';
+
+interface UnknownErrorPageProps {
+  error: Error;
+}
+
+const UnknownErrorPage: React.FC<UnknownErrorPageProps> = ({ error }) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex justify-between items-center flex-col pt-12 pl-12 pr-12 pb-12 h-screen gap-6">
+      <div className="flex gap-2 flex-col w-full">
+        <Typography type="title">{t('unknown-error-page-title')}</Typography>
+        <Typography type="body">
+          {t('unknown-error-page-description')}
+        </Typography>
+      </div>
+      <div className="flex flex-col w-full h-full gap-2 overflow-auto">
+        <Typography type="code">{`${t('unknown-error-occur-message')} : ${
+          error.message
+        }`}</Typography>
+        {error.stack?.split('\n').map((errorStack) => (
+          <Typography className="break-all" type="code" key={errorStack}>
+            {errorStack}
+          </Typography>
+        ))}
+      </div>
+      <a href={PathName.MAP_PAGE}>
+        <button
+          type="button"
+          className="px-6 py-2 rounded-md bg-primary hover:pg-primary-hover text-white w-fit"
+        >
+          {t('back-to-home-button-text')}
+        </button>
+      </a>
+    </div>
+  );
+};
+
+export default UnknownErrorPage;

--- a/src/stories/BorderRadius.stories.tsx
+++ b/src/stories/BorderRadius.stories.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { ComponentStory } from '@storybook/react';
 import 'index.css';
 
 export default {
@@ -7,6 +6,6 @@ export default {
   component: 'div',
 };
 
-export const RoundedMd: ComponentStory<'div'> = () => (
+export const RoundedMd = () => (
   <div className="bg-primary text-white p-4 rounded-md">Rounded Md</div>
 );

--- a/src/stories/Color.stories.tsx
+++ b/src/stories/Color.stories.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { ComponentStory } from '@storybook/react';
 import 'index.css';
 
 export default {
@@ -7,34 +6,28 @@ export default {
   component: 'div',
 };
 
-export const Primary: ComponentStory<'div'> = () => (
+export const Primary = () => (
   <div className="bg-primary text-white p-4">Primary</div>
 );
 
-export const Secondary: ComponentStory<'div'> = () => (
+export const Secondary = () => (
   <div className="bg-secondary text-white p-4">Secondary</div>
 );
 
-export const Error: ComponentStory<'div'> = () => (
-  <div className="bg-error text-white p-4">Error</div>
-);
+export const Error = () => <div className="bg-error text-white p-4">Error</div>;
 
-export const Active: ComponentStory<'div'> = () => (
+export const Active = () => (
   <div className="bg-active text-white p-4">Active</div>
 );
 
-export const Link: ComponentStory<'div'> = () => (
-  <div className="bg-link text-white p-4">Link</div>
-);
+export const Link = () => <div className="bg-link text-white p-4">Link</div>;
 
-export const Placeholder: ComponentStory<'div'> = () => (
+export const Placeholder = () => (
   <div className="bg-placeholder text-white p-4">Placeholder</div>
 );
 
-export const Disabled: ComponentStory<'div'> = () => (
+export const Disabled = () => (
   <div className="bg-disabled text-white p-4">Disabled</div>
 );
 
-export const Text: ComponentStory<'div'> = () => (
-  <div className="bg-text text-white p-4">Text</div>
-);
+export const Text = () => <div className="bg-text text-white p-4">Text</div>;

--- a/src/stories/LocateButton.stories.tsx
+++ b/src/stories/LocateButton.stories.tsx
@@ -1,14 +1,13 @@
-// create components/map/LocateButton.tsx storybook
 import React from 'react';
 import LocateButton from 'components/map/LocateButton';
-import { ComponentStory } from '@storybook/react';
+import { StoryFn } from '@storybook/react';
 
 export default {
   title: 'LocateButton',
   component: LocateButton,
 };
 
-const Template: ComponentStory<typeof LocateButton> = (args) => (
+const Template: StoryFn<typeof LocateButton> = (args) => (
   <LocateButton {...args} />
 );
 

--- a/src/stories/Map.stories.tsx
+++ b/src/stories/Map.stories.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { StoryFn } from '@storybook/react';
 import { Map, MapMarker } from 'react-kakao-maps-sdk';
 
 export default {
   title: 'Map',
   component: Map,
-} as ComponentMeta<typeof Map>;
+};
 
-export const DefaultMap: ComponentStory<typeof Map> = () => (
+export const DefaultMap: StoryFn<typeof Map> = () => (
   <Map
     className="w-[500px] h-[400px]"
     center={{ lat: 37.566826, lng: 126.9786567 }}

--- a/src/stories/Shadow.stories.tsx
+++ b/src/stories/Shadow.stories.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { ComponentStory } from '@storybook/react';
 import 'index.css';
 
 export default {
@@ -24,14 +23,14 @@ const Card: React.FC<CardProps> = (props) => {
   );
 };
 
-export const DropShadow: ComponentStory<'div'> = () => (
+export const DropShadow = () => (
   <Card className="drop-shadow">Drop Shadow</Card>
 );
 
-export const DropShadowMd: ComponentStory<'div'> = () => (
+export const DropShadowMd = () => (
   <Card className="drop-shadow-md">Drop Shadow Md</Card>
 );
 
-export const DropShadowMdReverse: ComponentStory<'div'> = () => (
+export const DropShadowMdReverse = () => (
   <Card className="drop-shadow-md-reverse">Drop Shadow Md Reverse</Card>
 );

--- a/src/stories/Typography.stories.tsx
+++ b/src/stories/Typography.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ComponentStory } from '@storybook/react';
+import { StoryFn } from '@storybook/react';
 import Typography from 'components/Typography';
 
 export default {
@@ -7,28 +7,28 @@ export default {
   component: Typography,
 };
 
-export const Title: ComponentStory<typeof Typography> = () => (
+export const Title: StoryFn<typeof Typography> = () => (
   <div className="flex flex-col">
     <Typography type="title">English Title Component</Typography>
     <Typography type="title">한글 제목 컴포넌트</Typography>
   </div>
 );
 
-export const SubTitle: ComponentStory<typeof Typography> = () => (
+export const SubTitle: StoryFn<typeof Typography> = () => (
   <div className="flex flex-col">
     <Typography type="subtitle">English SubTitle Component</Typography>
     <Typography type="subtitle">한글 부제목 컴포넌트</Typography>
   </div>
 );
 
-export const BodyText: ComponentStory<typeof Typography> = () => (
+export const BodyText: StoryFn<typeof Typography> = () => (
   <div className="flex flex-col">
     <Typography type="body">English Body Component</Typography>
     <Typography type="body">한글 본문 컴포넌트</Typography>
   </div>
 );
 
-export const Caption: ComponentStory<typeof Typography> = () => (
+export const Caption: StoryFn<typeof Typography> = () => (
   <div className="flex flex-col">
     <Typography type="caption">English Caption Component</Typography>
     <Typography type="caption">한글 설명 컴포넌트</Typography>

--- a/src/utils/i18n/locales/ko_KR/translation.json
+++ b/src/utils/i18n/locales/ko_KR/translation.json
@@ -1,4 +1,7 @@
 {
+  "not-found-error-page-title": "페이지를 찾을 수 없어요.",
+  "not-found-error-page-description": "찾을 수 없는 경로입니다.",
+  "back-to-home-button-text": "홈으로 돌아가기",
   "map-navigator-menu-text": "지도",
   "profile-navigator-menu-text": "마이페이지"
 }

--- a/src/utils/i18n/locales/ko_KR/translation.json
+++ b/src/utils/i18n/locales/ko_KR/translation.json
@@ -2,6 +2,9 @@
   "not-found-error-page-title": "페이지를 찾을 수 없어요.",
   "not-found-error-page-description": "찾을 수 없는 경로입니다.",
   "back-to-home-button-text": "홈으로 돌아가기",
+  "unknown-error-page-title": "알 수 없는 오류가 발생했어요.",
+  "unknown-error-page-description": "알 수 없는 오류가 발생했어요. 관리자에게 문의해주세요.",
+  "unknown-error-occur-message" : "다음과 같은 에러가 발생했습니다.",
   "map-navigator-menu-text": "지도",
   "profile-navigator-menu-text": "마이페이지"
 }

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -17,6 +17,10 @@ module.exports = {
         13.5: '3.375rem', // 54px
       },
     },
+    fontFamily: {
+      display: ['Noto Sans KR', 'Roboto', 'sans-serif'],
+      mono: ['Noto Sans Mono', 'monospace'],
+    },
     colors: {
       ...colors,
       primary: '#53B860',


### PR DESCRIPTION
# 관련 이슈

#34 ErrorBoundary를 추가해서 에러 화면을 보여준다.

# 내용

다음과 같은 내용을 구현했습니다.

* `NotFoundErrorPage`를 구현했습니다. 알 수 없는 경로는 `NotFoundErrorPage` 페이지를 보여주게 됩니다.
* `UnknownErrorPage`를 구현했습니다. 
* `ErrorBoundary`를 구현하여 컴포넌트에서 잡아내지 못한 오류가 발생하면 StackTrace와 함께 어떤 오류가 발생했는지 보여주도록 설정했습니다. 잡아내지 못한 오류는 `UnknownErrorPage`에서 보여주게 됩니다.
* font 규칙을 `index.css`가 아닌 `tailwind.config.cjs`에서 한번에 관리할 수 있도록 수정했습니다.
* `Typography`에 코드 내용을 보여줄 수 있는 mono font 형식의 `code` 타입을 추가했습니다.
* deprecated 된 storybook 함수 대신 7.0 버전에서 추가된 함수를 사용하였습니다.

eslint 규칙에 다음과 같은 내용을 추가했습니다.

* `_` 로 시작하는 변수는 사용하지 않는 변수로 잡아내지 않게 수정했습니다.

네트워크 오류에 대한 에러 페이지 ( 인터넷이 없다던가... ) 는 만들 필요가 생길 때 작업할 예정입니다.
401 에러가 발생한 경우는 모달을 띄워줄 예정이기 때문에 굳이 에러페이지로 만들진 않았습니다.

추가로 버튼 컴포넌트가 없어 임의로 형태만 잡아두었습니다. 이후 컴포넌트가 생기면 변경할 예정입니다.

# 미리보기

| 내용 | 스크린샷 |
| -- | ---- |
| 알 수 없는 페이지에 대해서 에러 메시지를 확인할 수 있다. | <img width="400" alt="image" src="https://user-images.githubusercontent.com/20200204/219947085-76be73e2-0f6e-454c-8707-98407afe0e6c.png"> |
| 알 수 없는 오류에 대해서 에러 메시지를 확인할 수 있다. |  <img width="400" alt="image" src="https://user-images.githubusercontent.com/20200204/219947044-e36a97fc-110d-48db-a476-143ca8534478.png"> |
