### PR TITLE
[#28] CI 과정에서 불필요하게 Dependency를 여러번 받는 과정을 간소화한다.

### DIFF
--- a/.github/workflows/beta-merge.yml
+++ b/.github/workflows/beta-merge.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
+          cache: 'yarn'
           
       - name: Create .env
         uses: SpicyPizza/create-envfile@v1.3
@@ -26,7 +27,7 @@ jobs:
           file_name: .env
 
       - name: Install Dependencies
-        run: yarn
+        run: yarn install --frozen-lockfile
 
       - name: Build
         run: yarn build

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -9,7 +9,7 @@ on:
     - ci/*
 
 jobs:
-  init:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
@@ -22,36 +22,19 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
+          cache: 'yarn'
                 
       - name: Install Dependencies
-        run: yarn    
+        run: yarn install --frozen-lockfile
       
       - name: Check lint
         run: yarn lint
-
-  build:
-    runs-on: ubuntu-latest
-    needs: init
-    steps:
-      - name: Checkout source code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
-      - run: git checkout HEAD
-      
-      - name: Set Up Node version
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
 
       - name: Create .env
         uses: SpicyPizza/create-envfile@v1.3
         with:
           envkey_VITE_KAKAO_API_KEY: ${{ secrets.VITE_KAKAO_API_KEY }}
           file_name: .env
-
-      - name: Install Dependencies
-        run: yarn
 
       - name: Build
         run: yarn build

--- a/.github/workflows/main-merge.yml
+++ b/.github/workflows/main-merge.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
+          cache: 'yarn'
           
       - name: Create .env
         uses: SpicyPizza/create-envfile@v1.3
@@ -26,7 +27,7 @@ jobs:
           file_name: .env
 
       - name: Install Dependencies
-        run: yarn
+        run: yarn install --frozen-lockfile
 
       - name: Build
         run: yarn build


### PR DESCRIPTION
# 관련 이슈

#28 CI 과정에서 불필요하게 Dependency를 여러번 받는 과정을 간소화한다.

# 내용

다음과 같은 내용을 구현했습니다.

CI 단계에서 init과 build 단계가 나눠져 있어서 불필요하게 `yarn install` 을 2번씩 하는 과정을 간단하게 변경했습니다.
또한 `yarn` 패키지들에 대해서 cache를 가능하게 해서 CI 속도를 개선했습니다. ( 다만 눈에 띄는 큰 차이는 없습니다. 🥲)

# 미리보기

N/A
